### PR TITLE
Bill/extendable song player

### DIFF
--- a/src/BusinessLayer/BusinessLayer.pro
+++ b/src/BusinessLayer/BusinessLayer.pro
@@ -11,9 +11,12 @@ HEADERS += \
     BusinessContainer.h \
     SongPlayer/SongPlayer.h \
     SongPlayer/I_SongPlayer.h \
-    SongControl/SongControl.h
+    SongControl/SongControl.h \
+    SongPlayer/I_MediaPlayer.h \
+    SongPlayer/GStreamerMediaPlayer.h
 
 SOURCES += \
     BusinessContainer.cpp \
     SongPlayer/SongPlayer.cpp \
-    SongControl/SongControl.cpp
+    SongControl/SongControl.cpp \
+    SongPlayer/GStreamerMediaPlayer.cpp

--- a/src/BusinessLayer/SongControl/SongControl.cpp
+++ b/src/BusinessLayer/SongControl/SongControl.cpp
@@ -23,10 +23,12 @@ QString SongControl::nextSong()
 QString SongControl::previousSong()
 {
     currentSongIndex_ -= 1;
+
     if (currentSongIndex_ < 0)
     {
         currentSongIndex_ = files_.size() - 1;
     }
+
     return files_[currentSongIndex_];
 }
 
@@ -38,12 +40,13 @@ QString SongControl::currentSong()
 QString SongControl::shuffleSong()
 {
 
-    if(files_.length() == 1)
+    if (files_.length() == 1)
     {
         return (files_[currentSongIndex_]);
     }
 
     int index = currentSongIndex_;
+
     do
     {
         currentSongIndex_ = (rand() % files_.size());
@@ -77,6 +80,7 @@ bool SongControl::readSongNames(QString dir, QVector<QString>& files_)
     {
         return false;
     }
+
     if (!relativeDirectory.cd("DataLayer/SongLibrary"))
     {
         return false;

--- a/src/BusinessLayer/SongPlayer/GStreamerMediaPlayer.cpp
+++ b/src/BusinessLayer/SongPlayer/GStreamerMediaPlayer.cpp
@@ -27,48 +27,54 @@ MediaStatus GStreamerMediaPlayer::mediaStatus()
 {
     MediaStatus status = MediaStatus::Error;
 
-    switch(mediaPlayer_.mediaStatus())
+    switch (mediaPlayer_.mediaStatus())
     {
         case QMediaPlayer::NoMedia:
         {
             status = MediaStatus::NoMedia;
             break;
         }
+
         default:
         {
             break;
         }
     }
-        return status;
+
+    return status;
 }
 
 PlayerState GStreamerMediaPlayer::state()
 {
     PlayerState status = PlayerState::Stopped;
 
-    switch(mediaPlayer_.state())
+    switch (mediaPlayer_.state())
     {
         case QMediaPlayer::StoppedState:
         {
             status = PlayerState::Stopped;
             break;
         }
+
         case QMediaPlayer::PausedState:
         {
             status = PlayerState::Paused;
             break;
         }
+
         case QMediaPlayer::PlayingState:
         {
             status = PlayerState::Playing;
             break;
         }
+
         default:
         {
             break;
         }
     }
-        return status;
+
+    return status;
 }
 
 void GStreamerMediaPlayer::setMedia(const QString& filePath)

--- a/src/BusinessLayer/SongPlayer/GStreamerMediaPlayer.cpp
+++ b/src/BusinessLayer/SongPlayer/GStreamerMediaPlayer.cpp
@@ -1,0 +1,85 @@
+#include "GStreamerMediaPlayer.h"
+
+GStreamerMediaPlayer::GStreamerMediaPlayer()
+{
+    connect(&mediaPlayer_, SIGNAL(stateChanged(QMediaPlayer::State)), this, SIGNAL(stateChanged()));
+    connect(&mediaPlayer_, SIGNAL(durationChanged(qint64)), this, SIGNAL(durationChanged(qint64)));
+    connect(&mediaPlayer_, SIGNAL(positionChanged(qint64)), this, SIGNAL(positionChanged(qint64)));
+    connect(&mediaPlayer_, SIGNAL(metaDataAvailableChanged(bool)), this, SIGNAL(metaDataAvailableChanged(bool)));
+}
+void GStreamerMediaPlayer::play()
+{
+    mediaPlayer_.play();
+}
+void GStreamerMediaPlayer::pause()
+{
+    mediaPlayer_.pause();
+}
+qint64 GStreamerMediaPlayer::position()
+{
+    return mediaPlayer_.position();
+}
+qint64 GStreamerMediaPlayer::duration()
+{
+    return mediaPlayer_.duration();
+}
+MediaStatus GStreamerMediaPlayer::mediaStatus()
+{
+    MediaStatus status = MediaStatus::Error;
+
+    switch(mediaPlayer_.mediaStatus())
+    {
+        case QMediaPlayer::NoMedia:
+        {
+            status = MediaStatus::NoMedia;
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
+        return status;
+}
+
+PlayerState GStreamerMediaPlayer::state()
+{
+    PlayerState status = PlayerState::Stopped;
+
+    switch(mediaPlayer_.state())
+    {
+        case QMediaPlayer::StoppedState:
+        {
+            status = PlayerState::Stopped;
+            break;
+        }
+        case QMediaPlayer::PausedState:
+        {
+            status = PlayerState::Paused;
+            break;
+        }
+        case QMediaPlayer::PlayingState:
+        {
+            status = PlayerState::Playing;
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
+        return status;
+}
+
+void GStreamerMediaPlayer::setMedia(const QString& filePath)
+{
+    mediaPlayer_.setMedia(QUrl::fromLocalFile(filePath));
+}
+void GStreamerMediaPlayer::setVolume(int volume)
+{
+    mediaPlayer_.setVolume(volume);
+}
+QString GStreamerMediaPlayer::metaData(const QString& key)
+{
+    return mediaPlayer_.metaData(key).toString();
+}

--- a/src/BusinessLayer/SongPlayer/GStreamerMediaPlayer.h
+++ b/src/BusinessLayer/SongPlayer/GStreamerMediaPlayer.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <QMediaPlayer>
+#include "I_MediaPlayer.h"
+
+class GStreamerMediaPlayer : public I_MediaPlayer
+{
+    Q_OBJECT
+public:
+    GStreamerMediaPlayer();
+    qint64 position();
+    qint64 duration();
+    MediaStatus mediaStatus();
+    void setMedia(const QString& filePath);
+    void setVolume(int volume);
+    QString metaData(const QString& key);
+    void play();
+    void pause();
+    PlayerState state();
+
+signals:
+    void stateChanged();
+    void durationChanged(qint64);
+    void positionChanged(qint64);
+    void metaDataAvailableChanged(bool);
+
+private:
+    QMediaPlayer mediaPlayer_;
+};

--- a/src/BusinessLayer/SongPlayer/I_MediaPlayer.h
+++ b/src/BusinessLayer/SongPlayer/I_MediaPlayer.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <QWidget>
+#include <QMediaMetaData>
+
+enum MediaStatus
+{
+    NoMedia,
+    Error
+};
+enum PlayerState
+{
+    Playing,
+    Stopped,
+    Paused
+};
+
+class I_MediaPlayer: public QObject
+{
+    Q_OBJECT
+
+public:
+    virtual qint64 position() = 0;
+    virtual qint64 duration() = 0;
+    virtual MediaStatus mediaStatus() = 0;
+    virtual void setMedia(const QString& filePath) = 0;
+    virtual void setVolume(int volume) = 0;
+    virtual QString metaData(const QString& key) = 0;
+    virtual PlayerState state() = 0;
+    virtual void play() = 0;
+    virtual void pause() = 0;
+signals:
+    void stateChanged();
+    void durationChanged(qint64);
+    void positionChanged(qint64);
+    void metaDataAvailableChanged(bool);
+};

--- a/src/BusinessLayer/SongPlayer/SongPlayer.cpp
+++ b/src/BusinessLayer/SongPlayer/SongPlayer.cpp
@@ -13,10 +13,10 @@ namespace
 }
 
 SongPlayer::SongPlayer(QWidget* parent) : QWidget(parent)
-  , controller_(new SongControl())
-  , shuffle_(false)
-  , loop_(false)
-  , mediaPlayer_(new GStreamerMediaPlayer())
+    , controller_(new SongControl())
+    , shuffle_(false)
+    , loop_(false)
+    , mediaPlayer_(new GStreamerMediaPlayer())
 {
     connect(mediaPlayer_.data(), SIGNAL(stateChanged()), this, SLOT(updateState()));
     connect(mediaPlayer_.data(), SIGNAL(durationChanged(qint64)), this, SLOT(durationChanged(qint64)));
@@ -32,7 +32,7 @@ void SongPlayer::updateState()
 {
     if (mediaPlayer_->position() >= mediaPlayer_->duration() && mediaPlayer_->duration() != -1)
     {
-         playNext();
+        playNext();
     }
 }
 
@@ -66,11 +66,11 @@ void SongPlayer::openNext()
 
 void SongPlayer::playNext()
 {
-    if(loop_)
+    if (loop_)
     {
         openFile();
     }
-    else if(shuffle_)
+    else if (shuffle_)
     {
         openShuffle();
     }
@@ -112,22 +112,23 @@ void SongPlayer::openShuffle()
 
 void SongPlayer::playPrevious()
 {
-    if(shuffle_)
-     {
-         openShuffle();
-     }
-     else
-     {
-         openPrevious();
-     }
-     togglePlayback();
+    if (shuffle_)
+    {
+        openShuffle();
+    }
+    else
+    {
+        openPrevious();
+    }
+
+    togglePlayback();
 }
 
 void SongPlayer::togglePlayback()
 {
     if (mediaPlayer_->mediaStatus() == MediaStatus::NoMedia)
     {
-        if(shuffle_)
+        if (shuffle_)
         {
             openShuffle();
         }
@@ -135,6 +136,7 @@ void SongPlayer::togglePlayback()
         {
             openFile();
         }
+
         mediaPlayer_->play();
     }
     else if (mediaPlayer_->state() == PlayerState::Playing)
@@ -170,7 +172,7 @@ void SongPlayer::adjustVolume(int volume)
 
 void SongPlayer::toggleShuffle()
 {
-    if(shuffle_)
+    if (shuffle_)
     {
         shuffle_ = false;
     }
@@ -182,7 +184,7 @@ void SongPlayer::toggleShuffle()
 
 void SongPlayer::toggleLoop()
 {
-    if(loop_)
+    if (loop_)
     {
         loop_ = false;
     }
@@ -215,20 +217,24 @@ QColor SongPlayer::getColor(QImage img)
 {
     int height = img.height() / 2;
     int width = img.width() / 2;
+
     //height and width are set to 0 when the song changes.
-    if(height != 0 && width != 0)
+    if (height != 0 && width != 0)
     {
         QColor color(img.pixel(width, height));
-        while(color.lightness() < MIN_LIGHT)
+
+        while (color.lightness() < MIN_LIGHT)
         {
             QColor temp(img.pixel(width += SKIP_PIXELS, height += SKIP_PIXELS));
             color = temp;
-            if(width >= img.width() - SKIP_PIXELS || height >= img.height() - SKIP_PIXELS)
+
+            if (width >= img.width() - SKIP_PIXELS || height >= img.height() - SKIP_PIXELS)
             {
-                QColor white = QColor(255,255,255,255);
+                QColor white = QColor(255, 255, 255, 255);
                 color = white;
             }
         }
+
         return color;
     }
 }

--- a/src/BusinessLayer/SongPlayer/SongPlayer.h
+++ b/src/BusinessLayer/SongPlayer/SongPlayer.h
@@ -6,7 +6,6 @@
 #include <QDebug>
 #include <QFileDialog>
 #include <QLabel>
-#include <QMediaPlayer>
 #include <QMouseEvent>
 #include <QShortcut>
 #include <QStandardPaths>
@@ -16,8 +15,8 @@
 #include <QWidget>
 #include <QProgressBar>
 #include <QScopedPointer>
-#include <QMediaMetaData>
 #include "../SongControl/SongControl.h"
+#include "I_MediaPlayer.h"
 
 class SongPlayer : public QWidget
 {
@@ -55,7 +54,7 @@ private:
     QAbstractButton* playButton_;
     QLabel* positionLabel_;
     QPoint offset_;
-    QMediaPlayer mediaPlayer_;
+    QScopedPointer<I_MediaPlayer> mediaPlayer_;
     qint64 position_;
     qint64 duration_;
     QString title_;
@@ -67,6 +66,5 @@ private:
 
 signals:
     void updateGUI(const QString& title, const QString& author, const QPixmap& cover);
-    void resetPosition(const QMediaPlayer& media);
     void updateProgress(qint64 position, qint64 duration);
 };

--- a/src/ViewLayer/ProgressBar/ProgressBar.cpp
+++ b/src/ViewLayer/ProgressBar/ProgressBar.cpp
@@ -5,7 +5,7 @@ namespace
     // Angle must specified be in 1/16th of a degree
     const int FULL_CIRCLE = 5760;   // 360 * 16
     const int START_ANGLE = -1440;  // The bottom of the circle is -90 * 16
-    const QColor DEFAULT_COLOR = QColor(219,160,56,255);
+    const QColor DEFAULT_COLOR = QColor(219, 160, 56, 255);
 }
 
 
@@ -18,7 +18,7 @@ ProgressBar::~ProgressBar()
 {
 }
 
-void ProgressBar::paintEvent(QPaintEvent *)
+void ProgressBar::paintEvent(QPaintEvent*)
 {
     QPainter p(this);
 

--- a/src/ViewLayer/ProgressBar/ProgressBar.h
+++ b/src/ViewLayer/ProgressBar/ProgressBar.h
@@ -18,5 +18,5 @@ private:
     QColor color_;
 
 protected:
-    void paintEvent(QPaintEvent *);
+    void paintEvent(QPaintEvent*);
 };

--- a/src/ViewLayer/SongPlayerView/SongPlayerView.cpp
+++ b/src/ViewLayer/SongPlayerView/SongPlayerView.cpp
@@ -4,23 +4,23 @@
 namespace
 {
     const QString STYLESHEET = "QSlider::groove:vertical {"
-                              "background: %1;"
-                              "width: 4px;"
-                              "position: absolute;}"
+                               "background: %1;"
+                               "width: 4px;"
+                               "position: absolute;}"
 
-                              "QSlider::handle:vertical {"
-                              "height: 16px;"
-                              "border-radius: 8px;"
-                              "background: grey;"
-                              "margin: 0  -6px;}"
+                               "QSlider::handle:vertical {"
+                               "height: 16px;"
+                               "border-radius: 8px;"
+                               "background: grey;"
+                               "margin: 0  -6px;}"
 
-                              "QSlider::add-page:vertical {"
-                              "background: %1;}"
+                               "QSlider::add-page:vertical {"
+                               "background: %1;}"
 
-                              "QSlider::sub-page:vertical {"
-                              "background: white;}";
+                               "QSlider::sub-page:vertical {"
+                               "background: white;}";
 
-    const QColor DEFAULT_COLOR = QColor(219,160,56,255);
+    const QColor DEFAULT_COLOR = QColor(219, 160, 56, 255);
 }
 
 SongPlayerView::SongPlayerView(SongPlayer& songPlayer, I_SongPlayerUi& ui, ProgressBar& bar)
@@ -42,7 +42,7 @@ SongPlayerView::SongPlayerView(SongPlayer& songPlayer, I_SongPlayerUi& ui, Progr
     connect(&ui_.loopButton(), SIGNAL(clicked()), this, SLOT(handleLoopButtonClicked()));
     connect(&ui_.volumeControl(), SIGNAL(valueChanged(int)), this, SLOT(handleVolumeControl()));
     connect(&songPlayer_, SIGNAL(updateGUI(const QString&, const QString&, const QPixmap&)), this, SLOT(updateGUI(const QString&, const QString&, const QPixmap&)));
-    connect(&songPlayer_,SIGNAL(updateProgress(qint64,qint64)), this,SLOT(updateProgress(qint64,qint64)));
+    connect(&songPlayer_, SIGNAL(updateProgress(qint64, qint64)), this, SLOT(updateProgress(qint64, qint64)));
     ui_.progressBarContainer().addWidget(&bar_);
 }
 
@@ -69,7 +69,7 @@ void SongPlayerView::handlePrevButtonClicked()
 
 void SongPlayerView::handleShuffleButtonClicked()
 {
-    if(ui_.loopButton().isChecked())
+    if (ui_.loopButton().isChecked())
     {
         ui_.loopButton().setChecked(false);
         songPlayer_.toggleLoop();
@@ -80,7 +80,7 @@ void SongPlayerView::handleShuffleButtonClicked()
 
 void SongPlayerView::handleLoopButtonClicked()
 {
-    if(ui_.shuffleButton().isChecked())
+    if (ui_.shuffleButton().isChecked())
     {
         ui_.shuffleButton().setChecked(false);
         songPlayer_.toggleShuffle();
@@ -102,6 +102,7 @@ void SongPlayerView::updateGUI(const QString& title, const QString& artist, cons
     QColor white = DEFAULT_COLOR;
     ui_.volumeControl().setStyleSheet(styleSheet.arg(white.name()));
     bar_.changeColor(white);
+
     if (!cover.isNull())
     {
         ui_.labelPic().setPixmap(cover);
@@ -117,6 +118,6 @@ void SongPlayerView::updateGUI(const QString& title, const QString& artist, cons
 
 void SongPlayerView::updateProgress(qint64 position, qint64 duration)
 {
-    bar_.progress = (double)position/(double)duration;
+    bar_.progress = (double)position / (double)duration;
     bar_.update();
 }

--- a/src/ViewLayer/SongPlayerView/SongPlayerView.h
+++ b/src/ViewLayer/SongPlayerView/SongPlayerView.h
@@ -33,5 +33,5 @@ private slots:
     void handleLoopButtonClicked();
     void handleVolumeControl();
     void updateGUI(const QString& title, const QString& artist, const QPixmap& cover);
-    void updateProgress(qint64 position,qint64 duration);
+    void updateProgress(qint64 position, qint64 duration);
 };


### PR DESCRIPTION
# Changelog

I made the `SongPlayer` class use an all new `I_mediaPlayer` class, and had the current method of playing songs in a `GStreamMediaPlayer` class. Later, when we add in the newer way of song loading, we can just make something like a `libMpgMediaPlayer` that provides the same interface and it should be plug and play!