### PR TITLE
SFT-90 Allow for shadow builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,8 @@ install:
     - (cd libmpg123 && ./configure && make && sudo make install)
 
 script:
-    - cd src
-    - qmake
-    - make
+    - mkdir build
+    - (cd build && qmake ../src && make)
     - "! (astyle *.h *.cpp -r --dry-run --options=astylerc | grep formatted)"
 
 language: cpp

--- a/src/BusinessLayer/BusinessLayer.pro
+++ b/src/BusinessLayer/BusinessLayer.pro
@@ -5,7 +5,7 @@ CONFIG += staticlib
     error("Could not find common.pri file!")
 }
 
-DESTDIR = ../../build/.lib
+DESTDIR = .lib
 
 HEADERS += \
     BusinessContainer.h \

--- a/src/OnboardMediaControl/OnboardMediaControl.pro
+++ b/src/OnboardMediaControl/OnboardMediaControl.pro
@@ -1,16 +1,17 @@
 TEMPLATE = app
-LIBS += -L../../build/.lib -lViewLayer -lBusinessLayer
+LIBS += -L../ViewLayer/.lib -L../BusinessLayer/.lib -lViewLayer -lBusinessLayer
 
 ! include(../common.pri){
     error("Could not find common.pri file!")
 }
 
 PRE_TARGETDEPS += \
- ../../build/.lib/*
+ ../ViewLayer/.lib/* \
+ ../BusinessLayer/.lib/*
 
 TARGET = OnboardMediaControl
 
-DESTDIR = ../../build
+DESTDIR = ../bin/
 
 SOURCES += \
     main.cpp \

--- a/src/ViewLayer/ViewLayer.pro
+++ b/src/ViewLayer/ViewLayer.pro
@@ -5,7 +5,7 @@ CONFIG += staticlib
 error("Could not find common.pri file!")
 }
 
-DESTDIR = ../../build/.lib
+DESTDIR = .lib
 
 HEADERS += \
     SongPlayerUI/SongPlayerUi.h \

--- a/src/common.pri
+++ b/src/common.pri
@@ -4,9 +4,9 @@ QT+=core gui widgets network multimedia
 CONFIG += static c++11 debug
 
 QMAKE_CXXFLAGS +=
-RCC_DIR= ../release
-DESTDIR = ../release
-OBJECTS_DIR = ../release/.obj
-MOC_DIR = ../release/.moc
-RCC_DIR = ../release/.rcc
-UI_DIR = ../release/.ui
+RCC_DIR= .
+DESTDIR = .
+OBJECTS_DIR = .obj
+MOC_DIR = .moc
+RCC_DIR = .rcc
+UI_DIR = .ui


### PR DESCRIPTION
Modified the file paths inside the `.pro` and `.pri` files to allow
for builds in different folders.
Updated Travis to work with new system.